### PR TITLE
version comparison & update manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# Cockatrice package is not up-to-date?
+# Cockatrice package version
 
-[![Latest Cockatrice Version](https://img.shields.io/github/release/cockatrice/cockatrice.svg?label=latest%20source%20package&colorB=4ac41d)](https://github.com/cockatrice/cockatrice/releases/latest)<br>
-[![](https://img.shields.io/badge/dynamic/json.svg?label=latest%20flathub%20package&colorB=4ac41d&prefix=v&query=$.modules[:2].sources[:1].branch&uri=https%3A%2F%2Fraw.githubusercontent.com%2Fflathub%2Fio.github.Cockatrice.cockatrice%2Fmaster%2Fio.github.Cockatrice.cockatrice.json)](https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.cockatrice.json#L49)<br>
+[![Cockatrice release history](https://img.shields.io/github/release/cockatrice/cockatrice.svg?label=latest%20source%20package&colorB=4ac41d)](https://github.com/cockatrice/cockatrice/releases/latest)<br>
+[![](https://img.shields.io/badge/dynamic/json.svg?label=latest%20flathub%20package&colorB=4ac41d&query=$.modules[:2].sources[:1].branch&uri=https%3A%2F%2Fraw.githubusercontent.com%2Fflathub%2Fio.github.Cockatrice.cockatrice%2Fmaster%2Fio.github.Cockatrice.cockatrice.json)](https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.cockatrice.json#L49)<br>
 <br>
-If both badges do not match, please send a PR and update the `branch` value in [this line](https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.cockatrice.json#L49) to bring them in sync again!<br>
-**Ignore leading `v`!**
+If the <kbd>source</kbd> and <kbd>flathub</kbd> version do not match, please send a PR and update the `branch` value in the [package.json](https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.cockatrice.json#L49) to bump the flathub release accordingly!<br>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Cockatrice package is not up-to-date?
+
+[![Latest Cockatrice Version](https://img.shields.io/github/release/cockatrice/cockatrice.svg?label=latest%20source%20package&colorB=4ac41d)](https://github.com/cockatrice/cockatrice/releases/latest)<br>
+[![](https://img.shields.io/badge/dynamic/json.svg?label=latest%20flathub%20package&colorB=4ac41d&prefix=v&query=$.modules[:2].sources[:1].branch&uri=https%3A%2F%2Fraw.githubusercontent.com%2Fflathub%2Fio.github.Cockatrice.cockatrice%2Fmaster%2Fio.github.Cockatrice.cockatrice.json)](https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.cockatrice.json#L49)<br>
+<br>
+If both badges do not match, please send a PR and update the `branch` value in [this line](https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.cockatrice.json#L49) to bring them in sync again!<br>
+**Ignore leading `v`!**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-# Cockatrice package version
+# Cockatrice flatpak package
 
 [![Cockatrice release history](https://img.shields.io/github/release/cockatrice/cockatrice.svg?label=latest%20source%20package&colorB=4ac41d)](https://github.com/cockatrice/cockatrice/releases/latest)<br>
 [![](https://img.shields.io/badge/dynamic/json.svg?label=latest%20flathub%20package&colorB=4ac41d&query=$.modules[:2].sources[:1].branch&uri=https%3A%2F%2Fraw.githubusercontent.com%2Fflathub%2Fio.github.Cockatrice.cockatrice%2Fmaster%2Fio.github.Cockatrice.cockatrice.json)](https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.cockatrice.json#L49)<br>
 <br>
 If the <kbd>source</kbd> and <kbd>flathub</kbd> version do not match, please send a PR and update the `branch` value in the [package.json](https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.cockatrice.json#L49) to bump the flathub release accordingly!<br>
+
+<br>
+
+### Useful links:
+ - [Maintaining an application on flathub](https://github.com/flathub/flathub/wiki/Maintaining-an-application-on-flathub)
+ - [Buildbot instance of flathub](https://flathub.org/builds)
+ - [List of all available flatpak packages on flathub](https://flathub.org/apps.html)
+  


### PR DESCRIPTION
added readme with simple update check and little tutorial

preview: https://github.com/tooomm/io.github.Cockatrice.cockatrice/blob/patch-1/README.md
*(Note: the leading `v` for the source package version will disappear once shields.io deploys their new code)*

**Edit:** is there a flatpak/flathub package page we can link to from the badge instead? @subpop 