### PR TITLE
 implement release version number + date

### DIFF
--- a/io.github.Cockatrice.appdata.xml
+++ b/io.github.Cockatrice.appdata.xml
@@ -16,7 +16,7 @@
 		<keyword>card</keyword>
 	</keywords>
 	<releases>
-		<release version="2.5.0" date="2018-03-02"/>
+		<release version="2.6.1" date="2018-07-17"/>
 	</releases>
 	<metadata_license>CC-BY-SA-3.0</metadata_license>
 	<project_license>GPL-2.0</project_license>

--- a/io.github.Cockatrice.appdata.xml
+++ b/io.github.Cockatrice.appdata.xml
@@ -16,7 +16,7 @@
 		<keyword>card</keyword>
 	</keywords>
 	<releases>
-		<release version="2.6.1" date="2018-07-17"/>
+		<release version="2.6.2" date="2018-12-20"/>
 	</releases>
 	<metadata_license>CC-BY-SA-3.0</metadata_license>
 	<project_license>GPL-2.0</project_license>

--- a/io.github.Cockatrice.appdata.xml
+++ b/io.github.Cockatrice.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop">
 	<id>cockatrice.desktop</id>
 	<name>Cockatrice</name>
-	<summary>Virtual tabletop for multiplayer card games</summary>
+	<summary>A cross-platform virtual tabletop for multiplayer card games</summary>
 	<developer_name>Cockatrice Project</developer_name>
 	<description>
 		<p>
@@ -15,6 +15,9 @@
 		<keyword>game</keyword>
 		<keyword>card</keyword>
 	</keywords>
+	<releases>
+		<release version="2.5.0" date="2018-03-02"/>
+	</releases>
 	<metadata_license>CC-BY-SA-3.0</metadata_license>
 	<project_license>GPL-2.0</project_license>
 	<url type="bugtracker">https://github.com/Cockatrice/Cockatrice/issues</url>

--- a/io.github.Cockatrice.appdata.xml
+++ b/io.github.Cockatrice.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop">
 	<id>cockatrice.desktop</id>
 	<name>Cockatrice</name>
-	<summary>A cross-platform virtual tabletop for multiplayer card games</summary>
+	<summary>Virtual tabletop for multiplayer card games</summary>
 	<developer_name>Cockatrice Project</developer_name>
 	<description>
 		<p>


### PR DESCRIPTION
Match https://github.com/flathub/io.github.Cockatrice.cockatrice/blob/master/io.github.Cockatrice.cockatrice.json#L49

Currently this information isn't shown at https://flathub.org/apps/details/io.github.Cockatrice.cockatrice

---

Change according to https://github.com/flathub/io.github.Cockatrice.cockatrice/pull/3#issuecomment-357711235