### PR TITLE
bump to 2.7.0

### DIFF
--- a/io.github.Cockatrice.appdata.xml
+++ b/io.github.Cockatrice.appdata.xml
@@ -16,7 +16,7 @@
 		<keyword>card</keyword>
 	</keywords>
 	<releases>
-		<release version="2.6.2" date="2018-12-20"/>
+		<release version="2.7.0" date="2019-03-04"/>
 	</releases>
 	<metadata_license>CC-BY-SA-3.0</metadata_license>
 	<project_license>GPL-2.0</project_license>

--- a/io.github.Cockatrice.cockatrice.json
+++ b/io.github.Cockatrice.cockatrice.json
@@ -46,7 +46,7 @@
       "sources": [
         {
           "type": "git",
-          "branch": "2018-12-20-Release-2.6.2",
+          "branch": "2019-03-04-Release-2.7.0",
           "url": "git://github.com/Cockatrice/Cockatrice.git"
         },
         {


### PR DESCRIPTION
https://github.com/Cockatrice/Cockatrice/releases/tag/2019-03-04-Release-2.7.0