### PR TITLE
Update appdata.xml

### DIFF
--- a/io.github.Cockatrice.appdata.xml
+++ b/io.github.Cockatrice.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-	<id>cockatrice.desktop</id>
+	<id>io.github.Cockatrice.cockatrice</id>
 	<name>Cockatrice</name>
 	<summary>Virtual tabletop for multiplayer card games</summary>
 	<developer_name>Cockatrice Project</developer_name>

--- a/io.github.Cockatrice.appdata.xml
+++ b/io.github.Cockatrice.appdata.xml
@@ -55,4 +55,8 @@
 	<url type="translate">https://transifex.com/cockatrice/cockatrice</url>
 	<url type="vcs-browser">https://github.com/Cockatrice/Cockatrice</url>
 	<launchable type="desktop-id">io.github.Cockatrice.cockatrice.desktop</launchable>
+	<provides>
+		<!-- Renamed from this -->
+		<id>cockatrice.desktop</id>
+	</provides>
 </component>

--- a/io.github.Cockatrice.appdata.xml
+++ b/io.github.Cockatrice.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
 	<id>io.github.Cockatrice.cockatrice</id>
 	<name>Cockatrice</name>
 	<summary>Virtual tabletop for multiplayer card games</summary>

--- a/io.github.Cockatrice.appdata.xml
+++ b/io.github.Cockatrice.appdata.xml
@@ -55,7 +55,4 @@
 	<url type="translate">https://transifex.com/cockatrice/cockatrice</url>
 	<url type="vcs-browser">https://github.com/Cockatrice/Cockatrice</url>
 	<launchable type="desktop-id">io.github.Cockatrice.cockatrice.desktop</launchable>
-	<provides>
-  		<id>io.github.Cockatrice.cockatrice</id>
-	</provides>
 </component>


### PR DESCRIPTION
- New app id

    `appstreamcli validate` gave me:
    >W: cockatrice.desktop:3: cid-desktopapp-is-not-rdns cockatrice.desktop

    The Flathub validate is not complaining, but the docs tell the same:
    [`<id>`](https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#id): [Each application should have a unique application ID, following the standard reverse-DNS schema](https://docs.flathub.org/docs/for-app-authors/requirements#application-id)

<br>

- New component header according to https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#header

<br>

- Fixing appstreamcli warning
    > `W: io.github.Cockatrice.cockatrice:59: circular-component-relation`

    The Flathub validate is also not complaining here.

<br>

- Referencing old name