### PR TITLE
CI: Update ubuntu container in validation workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ jobs:
   validate-appdata:
     name: Validate AppData
     runs-on: ubuntu-latest
-    container: ubuntu:mantic   # see #49, can be changed to ubuntu:rolling later
+    container: ubuntu:rolling
     steps:
     - uses: actions/checkout@v4
     - run: apt-get update


### PR DESCRIPTION
Fixes #53

Mantic and newer is needed for a reasonably recent appstream version to validate the manifest. Rolling keeps us up to date.