### PR TITLE
Fix release and description key

### DIFF
--- a/io.github.Cockatrice.cockatrice.metainfo.xml
+++ b/io.github.Cockatrice.cockatrice.metainfo.xml
@@ -6,9 +6,6 @@
 	<developer_name>Cockatrice Project</developer_name>
 	<releases>
 		<release version="2025-02-10-Release-2.10.0" date="2025-02-10">
-			<description></description>
-		</release>
-		<release version="2.9.0" date="2023-09-14">
 			<description>
 				<p>Please go to our GitHub repository for all details about this release.</p>
 			</description>

--- a/io.github.Cockatrice.cockatrice.metainfo.xml
+++ b/io.github.Cockatrice.cockatrice.metainfo.xml
@@ -6,9 +6,7 @@
 	<developer_name>Cockatrice Project</developer_name>
 	<releases>
 		<release version="2025-02-10-Release-2.10.0" date="2025-02-10">
-			<description>
-				<p>Please go to our GitHub repository for all details about this release.</p>
-			</description>
+			<description> </description>
 			<url>https://github.com/Cockatrice/Cockatrice/releases/latest</url>
 		</release>
 	</releases>


### PR DESCRIPTION
Old version tag did not match the full tag, but the version number only.
The tag structure needs to be fixed upstream.

The auto-updater on new upstream releases gets confused by this.