### PR TITLE
Fake "empty" description

### DIFF
--- a/io.github.Cockatrice.cockatrice.metainfo.xml
+++ b/io.github.Cockatrice.cockatrice.metainfo.xml
@@ -6,7 +6,9 @@
 	<developer_name>Cockatrice Project</developer_name>
 	<releases>
 		<release version="2025-02-10-Release-2.10.0" date="2025-02-10">
-			<description>&nbsp;</description>
+			<description>
+				<p></p>
+			</description>
 			<url>https://github.com/Cockatrice/Cockatrice/releases/latest</url>
 		</release>
 	</releases>

--- a/io.github.Cockatrice.cockatrice.metainfo.xml
+++ b/io.github.Cockatrice.cockatrice.metainfo.xml
@@ -6,7 +6,7 @@
 	<developer_name>Cockatrice Project</developer_name>
 	<releases>
 		<release version="2025-02-10-Release-2.10.0" date="2025-02-10">
-			<description> </description>
+			<description>Please go to our GitHub repository for all details about this release.</description>
 			<url>https://github.com/Cockatrice/Cockatrice/releases/latest</url>
 		</release>
 	</releases>

--- a/io.github.Cockatrice.cockatrice.metainfo.xml
+++ b/io.github.Cockatrice.cockatrice.metainfo.xml
@@ -6,7 +6,7 @@
 	<developer_name>Cockatrice Project</developer_name>
 	<releases>
 		<release version="2025-02-10-Release-2.10.0" date="2025-02-10">
-			<description>Please go to our GitHub repository for all details about this release.</description>
+			<description>&nbsp;</description>
 			<url>https://github.com/Cockatrice/Cockatrice/releases/latest</url>
 		</release>
 	</releases>


### PR DESCRIPTION
URL is not shown with empty description at all, and just using `space` in description is not recognized.

![image](https://github.com/user-attachments/assets/0c5c6af3-5caa-4cc8-a176-ecfdd113ec58)

Trying html code for space instead. Objection is to only display the url with its automatically applied `Get more information` to display, not the extra line of description and have all visible and clickable right away:
![image](https://github.com/user-attachments/assets/82324ee2-1f40-44dc-86dd-e573ccda7a05)
