### PR TITLE
Add release URL automatically on version bumps

### DIFF
--- a/io.github.Cockatrice.cockatrice.json
+++ b/io.github.Cockatrice.cockatrice.json
@@ -62,7 +62,7 @@
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d-]+Release-[\\d.]+)$",
-                        "release-url-template": "https://github.com/Cockatrice/Cockatrice/releases/latest"
+                        "release-url-template": "https://github.com/Cockatrice/Cockatrice/releases/latest",
                         "is-main-source": true
                     }
                 },

--- a/io.github.Cockatrice.cockatrice.json
+++ b/io.github.Cockatrice.cockatrice.json
@@ -62,6 +62,7 @@
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d-]+Release-[\\d.]+)$",
+                        "release-url-template": "https://github.com/Cockatrice/Cockatrice/releases/latest"
                         "is-main-source": true
                     }
                 },

--- a/io.github.Cockatrice.cockatrice.metainfo.xml
+++ b/io.github.Cockatrice.cockatrice.metainfo.xml
@@ -6,7 +6,6 @@
 	<developer id="io.github.cockatrice">
 		<name>Cockatrice Project</name>
 	</developer>
-	<!-- Include <url> key with link to /latest for each release, see https://github.com/flathub-infra/flatpak-external-data-checker/issues/466 -->
 	<releases>
 		<release version="2026-05-23-Release-3.0.1" date="2026-05-23">
 			<description/>


### PR DESCRIPTION
https://github.com/flathub-infra/flatpak-external-data-checker/issues/466 got added.

Docs: https://github.com/flathub-infra/flatpak-external-data-checker#release-url-template