### PR TITLE
Use direct link to GH release in URL template

### DIFF
--- a/io.github.Cockatrice.cockatrice.json
+++ b/io.github.Cockatrice.cockatrice.json
@@ -62,7 +62,7 @@
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d-]+Release-[\\d.]+)$",
-                        "release-url-template": "https://github.com/Cockatrice/Cockatrice/releases/latest",
+                        "release-url-template": "https://github.com/Cockatrice/Cockatrice/releases/tag/$version",
                         "is-main-source": true
                     }
                 },


### PR DESCRIPTION
Would currently link to
https://github.com/Cockatrice/Cockatrice/releases/tag/2026-06-26-Release-3.0.2
instead of
https://github.com/Cockatrice/Cockatrice/releases/latest

While they resolve to the same right now, it can happen that the flathub page is not updated with a new release and users are redirected to an even newer, not matching release history.

This change uses a version variable which resolves to the release version and allows to link to the exact GH Release page.